### PR TITLE
Moving interface method from binder codeunit to interface codeunit

### DIFF
--- a/app.json
+++ b/app.json
@@ -13,8 +13,8 @@
   "capabilities": [],
   "dependencies": [],
   "screenshots": [],
-  "platform": "13.0.0.0",
-  "application": "13.0.0.0",
+  "platform": "11.0.0.0",
+  "application": "11.0.0.0",
   "idRange": {
     "from": 50100,
     "to": 50149

--- a/src/Car/ICar.al
+++ b/src/Car/ICar.al
@@ -17,12 +17,23 @@ codeunit 50100 ICar
     var
         topSpeed: decimal;
     begin
-        _binder.OnGetTopSpeed(topSpeed, _binder.GetBindingID());
+        OnGetTopSpeed(topSpeed, _binder.GetBindingID());
         exit(topSpeed);
     end;
 
     procedure GetEngine(var engineOut: Codeunit IEngine)
     begin
-        _binder.OnGetEngine(engineOut, _binder.GetBindingID());
+        OnGetEngine(engineOut, _binder.GetBindingID());
+    end;
+
+    
+    [IntegrationEvent(false, false)]
+    procedure OnGetTopSpeed(var topSpeed: Decimal; bindingID: Guid)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    procedure OnGetEngine(var engine: Codeunit IEngine; bindingID: Guid)
+    begin
     end;
 }

--- a/src/Car/ICarBinder.al
+++ b/src/Car/ICarBinder.al
@@ -65,14 +65,4 @@ codeunit 50101 ICarBinder
     procedure OnBindInterfaceToImplementation(implementationCodeunit: Variant; var bindingIDOut: Guid)
     begin
     end;
-
-    [IntegrationEvent(false, false)]
-    procedure OnGetTopSpeed(var topSpeed: Decimal; bindingID: Guid)
-    begin
-    end;
-
-    [IntegrationEvent(false, false)]
-    procedure OnGetEngine(var engine: Codeunit IEngine; bindingID: Guid)
-    begin
-    end;
 }

--- a/src/Car/Skoda.al
+++ b/src/Car/Skoda.al
@@ -26,7 +26,7 @@ codeunit 50102 Skoda
         _engine.Construct(Codeunit::GasolineEngine);
     end;
 
-    [EventSubscriber(ObjectType::Codeunit, Codeunit::ICarBinder, 'OnGetTopSpeed', '', true, true)]
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::ICar, 'OnGetTopSpeed', '', true, true)]
     local procedure OnGetTopSpeed(var topSpeed: Decimal; bindingID: Guid)
     begin
         if (bindingID <> _bindingID) then
@@ -35,7 +35,7 @@ codeunit 50102 Skoda
         topSpeed := 200.00;
     end;
 
-    [EventSubscriber(ObjectType::Codeunit, Codeunit::ICarBinder, 'OnGetEngine', '', true, true)]
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::ICar, 'OnGetEngine', '', true, true)]
     local procedure OnGetEngine(var engine: Codeunit IEngine; bindingID: Guid)
     begin
         if (bindingID <> _bindingID) then

--- a/src/Car/Tesla.al
+++ b/src/Car/Tesla.al
@@ -26,7 +26,7 @@ codeunit 50103 Tesla
         _engine.Construct(Codeunit::ElectricEngine);
     end;
 
-    [EventSubscriber(ObjectType::Codeunit, Codeunit::ICarBinder, 'OnGetTopSpeed', '', true, true)]
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::ICar, 'OnGetTopSpeed', '', true, true)]
     local procedure OnGetTopSpeed(var topSpeed: Decimal; bindingID: Guid)
     begin
         if (bindingID <> _bindingID) then
@@ -35,7 +35,7 @@ codeunit 50103 Tesla
         topSpeed := 400.00;
     end;
 
-    [EventSubscriber(ObjectType::Codeunit, Codeunit::ICarBinder, 'OnGetEngine', '', true, true)]
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::ICar, 'OnGetEngine', '', true, true)]
     local procedure OnGetEngine(var engine: Codeunit IEngine; bindingID: Guid)
     begin
         if (bindingID <> _bindingID) then

--- a/src/Engine/ElectricEngine.al
+++ b/src/Engine/ElectricEngine.al
@@ -22,7 +22,7 @@ codeunit 50106 ElectricEngine
         IEngineBinder.OnBindInterfaceToImplementation(codeunitVariant, _bindingID);
     end;
 
-    [EventSubscriber(ObjectType::Codeunit, Codeunit::IEngineBinder, 'OnGetHorsePower', '', true, true)]
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::IEngine, 'OnGetHorsePower', '', true, true)]
     local procedure OnGetTopSpeed(var horsePower: Decimal; bindingID: Guid)
     begin
         if (bindingID <> _bindingID) then

--- a/src/Engine/GasolineEngine.al
+++ b/src/Engine/GasolineEngine.al
@@ -22,7 +22,7 @@ codeunit 50107 GasolineEngine
         IEngineBinder.OnBindInterfaceToImplementation(codeunitVariant, _bindingID);
     end;
 
-    [EventSubscriber(ObjectType::Codeunit, Codeunit::IEngineBinder, 'OnGetHorsePower', '', true, true)]
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::IEngine, 'OnGetHorsePower', '', true, true)]
     local procedure OnGetTopSpeed(var horsePower: Decimal; bindingID: Guid)
     begin
         if (bindingID <> _bindingID) then

--- a/src/Engine/IEngine.al
+++ b/src/Engine/IEngine.al
@@ -17,7 +17,13 @@ codeunit 50104 IEngine
     var
         horsePower: decimal;
     begin
-        _binder.OnGetHorsePower(horsePower, _binder.GetBindingID());
+        OnGetHorsePower(horsePower, _binder.GetBindingID());
         exit(horsePower);
+    end;
+
+
+    [IntegrationEvent(false, false)]
+    procedure OnGetHorsePower(var horsePower: Decimal; bindingID: Guid)
+    begin
     end;
 }

--- a/src/Engine/IEngineBinder.al
+++ b/src/Engine/IEngineBinder.al
@@ -65,9 +65,4 @@ codeunit 50105 IEngineBinder
     procedure OnBindInterfaceToImplementation(implementationCodeunit: Variant; var bindingIDOut: Guid)
     begin
     end;
-
-    [IntegrationEvent(false, false)]
-    procedure OnGetHorsePower(var horsePower: Decimal; bindingID: Guid)
-    begin
-    end;
 }


### PR DESCRIPTION
I suggest moving the interface methods from the binder codeunit into the interface codeunit.

Before this change, it feels as if the specific "class" codeunits are implementing the binder, rather than the interface, because they subscribe to events from binder, rather than the interface.

After this change, the interface codeunit rises events on itself, and specific "class" codeunits respond to these events. Functionally, nothing changes.

However, everything changes for the "consumer" - whoever writes a new codeunit, will "implement" events from the interface, and the binder remains completely transparent to them.

(Please ignore the switch from 13.0.0.0 to 11.0.0.0 - I had a v.11 instance ready, and it was simpler for me to play with this there.